### PR TITLE
feat: Change heading to reflect actual app

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -66,11 +66,9 @@ export default function Home() {
       <div className="container mx-auto px-6 py-8 max-w-6xl">
         <header className="mb-8">
           <h1 className="text-3xl font-semibold text-foreground mb-2">
-            Starter App
+            Horizon Lite
           </h1>
-          <p className="text-muted-foreground">
-            Full-stack monorepo with Vite, tRPC, React Query, and PostgreSQL
-          </p>
+          
         </header>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">


### PR DESCRIPTION
The original app name was not reflective of the intent for Horizon Lite