### PR TITLE
Add flexible sorting to Intel Feed with keyset pagination

### DIFF
--- a/client/src/pages/IntelFeed.tsx
+++ b/client/src/pages/IntelFeed.tsx
@@ -5,16 +5,17 @@ import { IntelSearch } from "@/components/IntelSearch";
 import { FeedCard } from "@/components/FeedCard";
 import { useInView } from "react-intersection-observer";
 
+type SortMode = "added" | "date";
+
 export default function IntelFeed() {
- 
-  
   const { ref, inView } = useInView();
 
   const [query, setQuery] = useState("");
   const [debounced] = useDebounce(query, 350);
+  const [sortBy, setSortBy] = useState<SortMode>("added");
 
   const searchQuery = trpc.intel.searchDocuments.useInfiniteQuery(
-    { q: debounced, limit: 30 },
+    { q: debounced, limit: 30, sortBy },
     {
       getNextPageParam: (last) => last.nextCursor ?? undefined,
       enabled: debounced.length >= 3,
@@ -22,7 +23,7 @@ export default function IntelFeed() {
   );
 
   const feedQuery = trpc.intel.feed.useInfiniteQuery(
-    { limit: 30 },
+    { limit: 30, sortBy },
     {
       getNextPageParam: (last) => last.nextCursor,
       enabled: debounced.length < 3,
@@ -52,16 +53,33 @@ export default function IntelFeed() {
 
   const items = debounced.length >= 3 ? searchItems : feedItems;
 
-
-  console.log({
-    pages: searchQuery.data?.pages.length,
-    nextCursor: searchQuery.data?.pages.at(-1)?.nextCursor,
-    hasNextPage: searchQuery.hasNextPage,
-  });
-  
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
       <IntelSearch query={query} setQuery={setQuery} />
+
+      {/* Sort toggle */}
+      <div className="flex gap-2 text-sm">
+        <button
+          onClick={() => setSortBy("added")}
+          className={`px-3 py-1 rounded-full border transition-colors ${
+            sortBy === "added"
+              ? "bg-foreground text-background border-foreground"
+              : "border-border text-muted-foreground hover:border-foreground"
+          }`}
+        >
+          Last Added
+        </button>
+        <button
+          onClick={() => setSortBy("date")}
+          className={`px-3 py-1 rounded-full border transition-colors ${
+            sortBy === "date"
+              ? "bg-foreground text-background border-foreground"
+              : "border-border text-muted-foreground hover:border-foreground"
+          }`}
+        >
+          By Date
+        </button>
+      </div>
 
       {debounced.length >= 3 && searchQuery.isFetching && (
         <div className="text-sm text-gray-500">Searching...</div>

--- a/server/routers/intelRouter.ts
+++ b/server/routers/intelRouter.ts
@@ -2,8 +2,7 @@ import { z } from "zod";
 import { router, publicProcedure } from "../trpc";
 import { db } from "../db";
 import { sql } from "drizzle-orm";
-import { paginateByUrl } from "../utils/paginate";
-import { query } from "express";
+import { paginateBy, paginateByUrl } from "../utils/paginate";
 
 type FeedRow = {
   url: string;
@@ -16,16 +15,19 @@ type FeedRow = {
   organizations: string[];
 };
 
+const sortBySchema = z.enum(["added", "date"]).default("added");
+
 export const intelRouter = router({
   feed: publicProcedure
     .input(
       z.object({
         cursor: z.string().optional(),
         limit: z.number().default(30),
+        sortBy: sortBySchema,
       }),
     )
     .query(async ({ input }) => {
-      const query = sql`
+      const baseQuery = sql`
         SELECT
           url,
           domain,
@@ -34,12 +36,12 @@ export const intelRouter = router({
           published_at,
           tone,
           themes,
-          organizations
+          organizations,
+          created_at
         FROM gdelt_documents
         WHERE published_at IS NOT NULL
-        ${input.cursor ? sql`AND url < ${input.cursor}` : sql``}
       `;
-      return paginateByUrl<FeedRow>(query, input.limit);
+      return paginateBy<FeedRow>(baseQuery, input.limit, input.sortBy, input.cursor);
     }),
 
   searchDocuments: publicProcedure
@@ -48,13 +50,14 @@ export const intelRouter = router({
         q: z.string().min(3),
         limit: z.number().default(30),
         cursor: z.string().optional(),
+        sortBy: sortBySchema,
       }),
     )
     .query(async ({ input }) => {
       try {
         const q = `%${input.q}%`;
 
-        const query = sql`
+        const baseQuery = sql`
           SELECT
             url,
             domain,
@@ -63,13 +66,13 @@ export const intelRouter = router({
             published_at,
             tone,
             themes,
-            organizations
+            organizations,
+            created_at
           FROM gdelt_documents
           WHERE title ILIKE ${q}
-          ${input.cursor ? sql`AND url < ${input.cursor}` : sql``}
         `;
 
-        return paginateByUrl<FeedRow>(query, input.limit);
+        return paginateBy<FeedRow>(baseQuery, input.limit, input.sortBy, input.cursor);
       } catch (err) {
         console.error("searchDocuments error:", err);
         throw err;

--- a/server/utils/paginate.ts
+++ b/server/utils/paginate.ts
@@ -6,11 +6,90 @@ type PageResult<T> = {
   nextCursor?: string;
 };
 
+export type SortMode = "added" | "date";
+
+// Composite cursor: encodes (sortValue, url) as a base64 JSON string
+function encodeCursor(sortValue: string, url: string): string {
+  return Buffer.from(JSON.stringify({ s: sortValue, u: url })).toString("base64");
+}
+
+function decodeCursor(cursor: string): { s: string; u: string } | null {
+  try {
+    return JSON.parse(Buffer.from(cursor, "base64").toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Paginate gdelt_documents by either:
+ *   "added" — ORDER BY created_at DESC (ingestion order, always reliable)
+ *   "date"  — ORDER BY published_at DESC NULLS LAST (article date; 1970 epochs excluded)
+ *
+ * Uses keyset pagination with a composite (sort_field, url) cursor so results
+ * are stable even when multiple rows share the same timestamp.
+ */
+export async function paginateBy<T>(
+  baseQuery: ReturnType<typeof sql>,
+  limit: number,
+  sortMode: SortMode,
+  cursor?: string
+): Promise<PageResult<T>> {
+  const limitPlusOne = limit + 1;
+  const decoded = cursor ? decodeCursor(cursor) : null;
+
+  let orderAndCursor;
+
+  if (sortMode === "added") {
+    orderAndCursor = decoded
+      ? sql`
+          AND (created_at, url) < (${decoded.s}::timestamptz, ${decoded.u})
+          ORDER BY created_at DESC, url DESC
+          LIMIT ${limitPlusOne}
+        `
+      : sql`
+          ORDER BY created_at DESC, url DESC
+          LIMIT ${limitPlusOne}
+        `;
+  } else {
+    // date mode: exclude epoch dates (published_at before 1971)
+    const epochFilter = sql`AND published_at > '1971-01-01'::timestamptz`;
+    orderAndCursor = decoded
+      ? sql`
+          ${epochFilter}
+          AND (published_at, url) < (${decoded.s}::timestamptz, ${decoded.u})
+          ORDER BY published_at DESC NULLS LAST, url DESC
+          LIMIT ${limitPlusOne}
+        `
+      : sql`
+          ${epochFilter}
+          ORDER BY published_at DESC NULLS LAST, url DESC
+          LIMIT ${limitPlusOne}
+        `;
+  }
+
+  const result = await db.execute(sql`${baseQuery} ${orderAndCursor}`);
+  const rows = result.rows as (T & { url: string; created_at?: string; published_at?: string })[];
+
+  let nextCursor: string | undefined;
+
+  if (rows.length > limit) {
+    const next = rows.pop()!;
+    const sortValue =
+      sortMode === "added"
+        ? (next.created_at ?? "")
+        : (next.published_at ?? "");
+    nextCursor = encodeCursor(sortValue, next.url);
+  }
+
+  return { items: rows as unknown as T[], nextCursor };
+}
+
+// Legacy export kept for any callers not yet migrated
 export async function paginateByUrl<T>(
   baseQuery: ReturnType<typeof sql>,
   limit: number
 ): Promise<PageResult<T>> {
-
   const limitPlusOne = limit + 1;
 
   const result = await db.execute(sql`
@@ -20,7 +99,6 @@ export async function paginateByUrl<T>(
   `);
 
   const rows = result.rows as T[];
-
   let nextCursor: string | undefined;
 
   if (rows.length > limit) {
@@ -28,8 +106,5 @@ export async function paginateByUrl<T>(
     nextCursor = (next as any)?.url;
   }
 
-  return {
-    items: rows,
-    nextCursor,
-  };
+  return { items: rows, nextCursor };
 }


### PR DESCRIPTION
## Summary
Replaced URL-based pagination with a robust keyset pagination system that supports multiple sort modes ("added" by ingestion date, or "date" by article publication date). This enables stable pagination when multiple documents share the same timestamp and provides users with flexible sorting options.

## Key Changes
- **New `paginateBy()` function** in `server/utils/paginate.ts`:
  - Implements keyset pagination using composite cursors encoding both sort value and URL
  - Supports two sort modes: "added" (ORDER BY created_at DESC) and "date" (ORDER BY published_at DESC)
  - Filters out epoch dates (pre-1971) in "date" mode to exclude invalid data
  - Uses tuple comparison `(sort_field, url) < (cursor_value, cursor_url)` for stable, efficient pagination

- **Cursor encoding/decoding**:
  - Composite cursors store both the sort field value and URL as base64-encoded JSON
  - Prevents pagination issues when multiple rows share identical timestamps

- **Frontend sorting UI** in `IntelFeed.tsx`:
  - Added toggle buttons to switch between "Last Added" and "By Date" sort modes
  - Sort preference is passed to both feed and search queries
  - Removed debug console.log statements

- **Router updates** in `intelRouter.ts`:
  - Both `feed` and `searchDocuments` procedures now accept `sortBy` parameter
  - Migrated from `paginateByUrl()` to `paginateBy()` with appropriate base queries
  - Added `created_at` field to SELECT statements for "added" sort mode

- **Backward compatibility**:
  - Legacy `paginateByUrl()` function retained for any unmigrated callers

## Implementation Details
- Keyset pagination is more efficient than offset-based pagination for large datasets
- Tuple comparison ensures deterministic ordering even with duplicate timestamps
- Epoch filter (published_at > '1971-01-01') prevents invalid historical dates from appearing in "date" mode

https://claude.ai/code/session_011HGao26xmLLJTKyuan5gzd