### PR TITLE
Add event coverage modal with headline clustering

### DIFF
--- a/client/src/components/FeedCard.tsx
+++ b/client/src/components/FeedCard.tsx
@@ -1,17 +1,39 @@
+import { useState, useEffect } from "react";
+import { trpc } from "@/lib/trpc";
+import { EventDetailModal } from "@/components/intelfeed/EventDetailModal";
+
 type Props = {
   doc: {
-    url: string
-    domain: string
-    title: string
-    image_url: string | null
-    published_at: string
-    tone: number
-    themes: string[]
-    organizations: string[]
-  }
-}
+    url: string;
+    domain: string;
+    title: string;
+    image_url: string | null;
+    published_at: string;
+    tone: number;
+    themes: string[];
+    organizations: string[];
+  };
+};
 
 export function FeedCard({ doc }: Props) {
+  const [coverageOpen, setCoverageOpen] = useState(false);
+  const [lookupRequested, setLookupRequested] = useState(false);
+
+  // Lazy: only fires the network request once the user clicks "Coverage"
+  const eventQuery = trpc.intel.eventsByDocUrl.useQuery(
+    { url: doc.url },
+    { enabled: lookupRequested, staleTime: 10 * 60 * 1000 },
+  );
+
+  const topEvent = eventQuery.data?.[0];
+
+  // Once data arrives after the user clicked, open the modal
+  useEffect(() => {
+    if (lookupRequested && topEvent) {
+      setCoverageOpen(true);
+    }
+  }, [lookupRequested, topEvent]);
+
   const toneColor =
     doc.tone < -5
       ? "text-red-600"
@@ -19,51 +41,62 @@ export function FeedCard({ doc }: Props) {
       ? "text-orange-500"
       : "text-gray-600";
 
+  function handleCoverageClick() {
+    if (topEvent) {
+      // Already loaded
+      setCoverageOpen(true);
+    } else {
+      // Trigger the lookup; useEffect above will open modal when it resolves
+      setLookupRequested(true);
+    }
+  }
+
   return (
-    <div className="border rounded-lg p-4 space-y-3">
-      <div className="flex justify-between text-sm text-gray-500">
-        <span>{doc.domain}</span>
-        <span>
-          {new Date(doc.published_at).toLocaleString()}
-        </span>
+    <>
+      <div className="border rounded-lg p-4 space-y-3">
+        <div className="flex justify-between text-sm text-gray-500">
+          <span>{doc.domain}</span>
+          <span>{new Date(doc.published_at).toLocaleString()}</span>
+        </div>
+
+        <h3 className="text-lg font-semibold">{doc.title}</h3>
+
+        <div className={`text-sm ${toneColor}`}>Tone: {doc.tone}</div>
+
+        <div className="flex flex-wrap gap-2">
+          {doc.themes?.slice(0, 5).map((theme) => (
+            <span key={theme} className="text-xs bg-gray-100 px-2 py-1 rounded">
+              {theme}
+            </span>
+          ))}
+        </div>
+
+        <div className="flex gap-4 text-sm">
+          <a href={doc.url} target="_blank" className="text-blue-600">
+            Open Article
+          </a>
+
+          <button className="text-blue-600">Webcut</button>
+
+          <button className="text-blue-600">Capture Snippet</button>
+
+          {/* Coverage button: loading state → hidden (no event) → clickable */}
+          {lookupRequested && eventQuery.isLoading ? (
+            <span className="text-gray-400 cursor-default">Loading…</span>
+          ) : lookupRequested && !topEvent ? null : (
+            <button onClick={handleCoverageClick} className="text-blue-600">
+              Coverage
+            </button>
+          )}
+        </div>
       </div>
 
-      <h3 className="text-lg font-semibold">
-        {doc.title}
-      </h3>
-
-      <div className={`text-sm ${toneColor}`}>
-        Tone: {doc.tone}
-      </div>
-
-      <div className="flex flex-wrap gap-2">
-        {doc.themes?.slice(0, 5).map((theme) => (
-          <span
-            key={theme}
-            className="text-xs bg-gray-100 px-2 py-1 rounded"
-          >
-            {theme}
-          </span>
-        ))}
-      </div>
-
-      <div className="flex gap-4 text-sm">
-        <a
-          href={doc.url}
-          target="_blank"
-          className="text-blue-600"
-        >
-          Open Article
-        </a>
-
-        <button className="text-blue-600">
-          Webcut
-        </button>
-
-        <button className="text-blue-600">
-          Capture Snippet
-        </button>
-      </div>
-    </div>
+      {coverageOpen && topEvent && (
+        <EventDetailModal
+          event={topEvent}
+          onClose={() => setCoverageOpen(false)}
+        />
+      )}
+    </>
   );
 }

--- a/client/src/components/intelfeed/EventDetailCoverageTab.tsx
+++ b/client/src/components/intelfeed/EventDetailCoverageTab.tsx
@@ -1,0 +1,387 @@
+import { useState, useMemo } from "react";
+import { ExternalLink, ChevronDown, ChevronUp, Newspaper, Loader2 } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+
+// ── Domain → country flag ─────────────────────────────────────────────────────
+
+const TLD_FLAGS: Record<string, string> = {
+  uk: "🇬🇧",
+  us: "🇺🇸",
+  de: "🇩🇪",
+  fr: "🇫🇷",
+  ru: "🇷🇺",
+  cn: "🇨🇳",
+  in: "🇮🇳",
+  br: "🇧🇷",
+  jp: "🇯🇵",
+  au: "🇦🇺",
+  ca: "🇨🇦",
+  it: "🇮🇹",
+  es: "🇪🇸",
+  nl: "🇳🇱",
+  se: "🇸🇪",
+  no: "🇳🇴",
+  pl: "🇵🇱",
+  ua: "🇺🇦",
+  il: "🇮🇱",
+  tr: "🇹🇷",
+};
+
+const DOMAIN_OVERRIDES: Record<string, string> = {
+  "reuters.com": "🇨🇦",
+  "apnews.com": "🇺🇸",
+  "bbc.com": "🇬🇧",
+  "aljazeera.com": "🇶🇦",
+  "cnn.com": "🇺🇸",
+  "foxnews.com": "🇺🇸",
+  "nytimes.com": "🇺🇸",
+  "theguardian.com": "🇬🇧",
+  "washingtonpost.com": "🇺🇸",
+  "dw.com": "🇩🇪",
+  "france24.com": "🇫🇷",
+  "rt.com": "🇷🇺",
+  "tass.com": "🇷🇺",
+  "xinhuanet.com": "🇨🇳",
+  "globo.com": "🇧🇷",
+  "timesofindia.com": "🇮🇳",
+};
+
+function domainToFlag(domain: string): string {
+  if (!domain) return "🌍";
+  const clean = domain.replace(/^www\./, "");
+  if (DOMAIN_OVERRIDES[clean]) return DOMAIN_OVERRIDES[clean];
+  const tld = clean.split(".").pop() ?? "";
+  return TLD_FLAGS[tld] ?? "🌍";
+}
+
+// ── Client-side clustering (word-overlap Jaccard similarity) ──────────────────
+
+type Headline = {
+  id: string;
+  title: string;
+  source: string;
+  url: string;
+  createdAt: string | null;
+};
+
+type Cluster = {
+  id: string;
+  size: number;
+  representative: string;
+  headlines: Headline[];
+};
+
+const STOP_WORDS = new Set([
+  "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
+  "of", "with", "by", "from", "is", "was", "are", "were", "be", "been",
+  "has", "have", "had", "it", "its", "this", "that", "as", "he", "she",
+  "they", "we", "i", "not", "no", "up", "out", "if", "so", "do", "did",
+  "will", "can", "may", "who", "what", "when", "where", "how", "his",
+  "her", "their", "our", "my", "your", "says", "said", "say",
+]);
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((w) => w.length > 2 && !STOP_WORDS.has(w)),
+  );
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  const intersection = [...a].filter((w) => b.has(w)).length;
+  const union = new Set([...a, ...b]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/** Greedy single-linkage clustering with Jaccard similarity threshold. */
+function clusterHeadlines(headlines: Headline[], threshold = 0.25): Cluster[] {
+  const tokens = headlines.map((h) => tokenize(h.title));
+  const assigned = new Array<number | null>(headlines.length).fill(null);
+  const clusters: { rep: number; members: number[] }[] = [];
+
+  for (let i = 0; i < headlines.length; i++) {
+    // Find closest existing cluster where at least one member exceeds threshold
+    let bestCluster = -1;
+    let bestSim = 0;
+
+    for (let ci = 0; ci < clusters.length; ci++) {
+      for (const mi of clusters[ci].members) {
+        const sim = jaccard(tokens[i], tokens[mi]);
+        if (sim > bestSim) {
+          bestSim = sim;
+          bestCluster = ci;
+        }
+      }
+    }
+
+    if (bestSim >= threshold) {
+      clusters[bestCluster].members.push(i);
+    } else {
+      clusters.push({ rep: i, members: [i] });
+    }
+    assigned[i] = bestCluster >= 0 && bestSim >= threshold ? bestCluster : clusters.length - 1;
+  }
+
+  // Only keep clusters with ≥2 members; singletons go into an "Other" group
+  const multi = clusters.filter((c) => c.members.length >= 2);
+  const singletonMembers = clusters
+    .filter((c) => c.members.length < 2)
+    .flatMap((c) => c.members);
+
+  const result: Cluster[] = multi
+    .sort((a, b) => b.members.length - a.members.length)
+    .map((c, idx) => ({
+      id: `cluster-${idx}`,
+      size: c.members.length,
+      representative: headlines[c.rep].title,
+      headlines: c.members.map((mi) => headlines[mi]),
+    }));
+
+  if (singletonMembers.length > 0) {
+    result.push({
+      id: "cluster-other",
+      size: singletonMembers.length,
+      representative: headlines[singletonMembers[0]].title,
+      headlines: singletonMembers.map((mi) => headlines[mi]),
+    });
+  }
+
+  return result;
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+const PREVIEW_COUNT = 5;
+
+function ClusterItem({ cluster }: { cluster: Cluster }) {
+  const [expanded, setExpanded] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+
+  const visible = showAll
+    ? cluster.headlines
+    : cluster.headlines.slice(0, PREVIEW_COUNT);
+
+  return (
+    <div className="rounded-lg border bg-background shadow-sm overflow-hidden">
+      {/* Cluster header */}
+      <button
+        className="w-full flex items-start gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        <span className="mt-0.5 flex-shrink-0 inline-flex items-center justify-center rounded-full bg-muted text-xs font-semibold w-8 h-5 tabular-nums">
+          {cluster.size}
+        </span>
+        <span className="flex-1 text-sm font-medium leading-snug line-clamp-2">
+          {cluster.representative}
+        </span>
+        <span className="flex-shrink-0 text-muted-foreground mt-0.5">
+          {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        </span>
+      </button>
+
+      {/* Expanded article list */}
+      {expanded && (
+        <div className="border-t divide-y">
+          {visible.map((h) => (
+            <div key={h.id} className="px-4 py-3 flex items-start gap-3">
+              <div className="flex-shrink-0 text-base leading-none mt-0.5">
+                {domainToFlag(h.source)}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-xs font-medium text-muted-foreground">
+                  {h.source}
+                </div>
+                <div className="mt-0.5 text-sm leading-snug">{h.title}</div>
+              </div>
+              <a
+                href={h.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex-shrink-0 text-muted-foreground hover:text-foreground transition-colors mt-0.5"
+                title="Open article"
+              >
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            </div>
+          ))}
+
+          {cluster.headlines.length > PREVIEW_COUNT && !showAll && (
+            <div className="px-4 py-3">
+              <button
+                onClick={() => setShowAll(true)}
+                className="text-sm text-blue-600 hover:underline"
+              >
+                Show all {cluster.headlines.length} articles ↓
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Coverage header ───────────────────────────────────────────────────────────
+
+function CoverageHeader({
+  mentionCount,
+  sourceCount,
+  avgTone,
+  sources,
+}: {
+  mentionCount: number;
+  sourceCount: number;
+  avgTone: number | null;
+  sources: string[];
+}) {
+  const PREVIEW_SOURCES = 6;
+  const visibleSources = sources.slice(0, PREVIEW_SOURCES);
+  const remaining = Math.max(0, sourceCount - PREVIEW_SOURCES);
+
+  const toneColor =
+    avgTone == null
+      ? "text-muted-foreground"
+      : avgTone < -5
+      ? "text-red-600"
+      : avgTone < -2
+      ? "text-orange-500"
+      : "text-emerald-600";
+
+  return (
+    <div className="rounded-lg border bg-background p-4 shadow-sm space-y-2">
+      <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        <Newspaper className="h-4 w-4" />
+        Coverage Overview
+      </div>
+      <div className="flex flex-wrap gap-4 text-sm">
+        <span>
+          <span className="font-semibold tabular-nums">{mentionCount}</span>{" "}
+          <span className="text-muted-foreground">total mentions</span>
+        </span>
+        <span>
+          <span className="font-semibold tabular-nums">{sourceCount}</span>{" "}
+          <span className="text-muted-foreground">unique sources</span>
+        </span>
+        {avgTone != null && (
+          <span className={toneColor}>
+            Tone: <span className="font-semibold">{avgTone.toFixed(1)}</span>
+          </span>
+        )}
+      </div>
+      {visibleSources.length > 0 && (
+        <div className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Sources: </span>
+          {visibleSources.map((s) => `${domainToFlag(s)} ${s}`).join(", ")}
+          {remaining > 0 && (
+            <span className="ml-1 text-muted-foreground">+{remaining} more</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+export function EventDetailCoverageTab({ eventId }: { eventId: string }) {
+  const { data, isLoading, isError, error } = trpc.intel.coverage.useQuery(
+    { eventId },
+    { staleTime: 5 * 60 * 1000 },
+  );
+
+  const clusters = useMemo(() => {
+    if (!data?.headlines || data.headlines.length === 0) return [];
+    return clusterHeadlines(data.headlines);
+  }, [data?.headlines]);
+
+  const uniqueSources = useMemo(() => {
+    if (!data?.headlines) return [];
+    return [...new Set(data.headlines.map((h) => h.source))];
+  }, [data?.headlines]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3 py-4">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading coverage data…
+        </div>
+        {[...Array(3)].map((_, i) => (
+          <div
+            key={i}
+            className="h-12 rounded-lg border bg-muted animate-pulse"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="py-4 text-sm text-muted-foreground">
+        Failed to load coverage: {error?.message ?? "Unknown error"}
+      </div>
+    );
+  }
+
+  if (!data || data.mentionCount < 5) {
+    return (
+      <div className="py-4 text-sm text-muted-foreground">
+        Not enough coverage data for this event (minimum 5 mentions required).
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <CoverageHeader
+        mentionCount={data.mentionCount}
+        sourceCount={data.sourceCount}
+        avgTone={data.avgTone}
+        sources={uniqueSources}
+      />
+
+      {clusters.length === 0 ? (
+        /* Fallback: flat list when clustering produces no groups */
+        <div className="rounded-lg border bg-background shadow-sm divide-y overflow-hidden">
+          {data.headlines.map((h) => (
+            <div key={h.id} className="px-4 py-3 flex items-start gap-3">
+              <div className="flex-shrink-0 text-base leading-none mt-0.5">
+                {domainToFlag(h.source)}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-xs font-medium text-muted-foreground">{h.source}</div>
+                <div className="mt-0.5 text-sm leading-snug">{h.title}</div>
+              </div>
+              <a
+                href={h.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex-shrink-0 text-muted-foreground hover:text-foreground transition-colors mt-0.5"
+              >
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <>
+          <p className="text-xs text-muted-foreground">
+            {clusters.length} narrative cluster{clusters.length !== 1 ? "s" : ""} detected
+            — sorted by mention count
+          </p>
+          <div className="space-y-2">
+            {clusters.map((cluster) => (
+              <ClusterItem key={cluster.id} cluster={cluster} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/intelfeed/EventDetailModal.tsx
+++ b/client/src/components/intelfeed/EventDetailModal.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react";
+import { X, MapPin, Users, Activity } from "lucide-react";
+import { EventDetailCoverageTab } from "./EventDetailCoverageTab";
+
+type EventSummary = {
+  globalEventId: string;
+  numMentions: number | null;
+  numSources: number | null;
+  avgTone: number | null;
+  actor1Name: string | null;
+  actor2Name: string | null;
+  eventTime: string | null;
+  actionGeoFullname: string | null;
+};
+
+type Tab = "overview" | "coverage";
+
+type Props = {
+  event: EventSummary;
+  onClose: () => void;
+};
+
+function Stat({
+  label,
+  value,
+  className = "",
+}: {
+  label: string;
+  value: string | number;
+  className?: string;
+}) {
+  return (
+    <div className="rounded-lg border bg-background px-3 py-2.5 shadow-sm">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className={`text-lg font-semibold tabular-nums mt-0.5 ${className}`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function OverviewTab({ event }: { event: EventSummary }) {
+  const toneColor =
+    event.avgTone == null
+      ? "text-muted-foreground"
+      : event.avgTone < -5
+      ? "text-red-600"
+      : event.avgTone < -2
+      ? "text-orange-500"
+      : "text-emerald-600";
+
+  return (
+    <div className="space-y-4 py-2">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Stat label="Mentions" value={event.numMentions ?? "—"} />
+        <Stat label="Sources" value={event.numSources ?? "—"} />
+        <Stat
+          label="Avg Tone"
+          value={event.avgTone != null ? event.avgTone.toFixed(1) : "—"}
+          className={toneColor}
+        />
+        <Stat
+          label="Event Time"
+          value={
+            event.eventTime
+              ? new Date(event.eventTime).toLocaleDateString()
+              : "—"
+          }
+        />
+      </div>
+
+      <div className="rounded-lg border bg-background p-4 space-y-3">
+        {(event.actor1Name || event.actor2Name) && (
+          <div className="flex items-start gap-2 text-sm">
+            <Users className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
+            <div>
+              <span className="text-muted-foreground">Actors: </span>
+              {[event.actor1Name, event.actor2Name].filter(Boolean).join(" ↔ ")}
+            </div>
+          </div>
+        )}
+
+        {event.actionGeoFullname && (
+          <div className="flex items-start gap-2 text-sm">
+            <MapPin className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
+            <div>
+              <span className="text-muted-foreground">Location: </span>
+              {event.actionGeoFullname}
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-start gap-2 text-sm">
+          <Activity className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
+          <div>
+            <span className="text-muted-foreground">Event ID: </span>
+            <code className="text-xs">{event.globalEventId}</code>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function EventDetailModal({ event, onClose }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>("coverage");
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      {/* Scrim */}
+      <div className="absolute inset-0 bg-black/40" aria-hidden="true" />
+
+      {/* Panel */}
+      <div className="relative z-10 w-full sm:max-w-2xl max-h-[90dvh] sm:max-h-[85vh] flex flex-col rounded-t-2xl sm:rounded-xl bg-background shadow-xl overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b flex-shrink-0">
+          <div>
+            <h2 className="text-base font-semibold leading-tight">
+              Event Coverage
+            </h2>
+            {(event.actor1Name || event.actor2Name) && (
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {[event.actor1Name, event.actor2Name].filter(Boolean).join(" ↔ ")}
+              </p>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1.5 hover:bg-muted transition-colors text-muted-foreground"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-1 px-5 pt-3 flex-shrink-0 border-b pb-0">
+          {(["coverage", "overview"] as Tab[]).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`px-4 py-2 text-sm font-medium capitalize border-b-2 transition-colors -mb-px ${
+                activeTab === tab
+                  ? "border-foreground text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {activeTab === "coverage" ? (
+            <EventDetailCoverageTab eventId={event.globalEventId} />
+          ) : (
+            <OverviewTab event={event} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/server/routers/intelRouter.ts
+++ b/server/routers/intelRouter.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { router, publicProcedure } from "../trpc";
 import { sql } from "drizzle-orm";
+import { db } from "../db";
 import { paginateBy } from "../utils/paginate";
 
 type FeedRow = {
@@ -76,5 +77,126 @@ export const intelRouter = router({
         console.error("searchDocuments error:", err);
         throw err;
       }
+    }),
+
+  /**
+   * Return all mention headlines for a GDELT event, for the Coverage tab.
+   * Joins gdelt_event_mentions → gdelt_documents to get titles.
+   */
+  coverage: publicProcedure
+    .input(z.object({ eventId: z.string() }))
+    .query(async ({ input }) => {
+      const mentionRows = await db.execute(sql`
+        SELECT
+          em.id,
+          em.url,
+          em.domain,
+          em.mention_time,
+          em.doc_tone,
+          d.title
+        FROM gdelt_event_mentions em
+        LEFT JOIN gdelt_documents d ON d.url = em.url
+        WHERE em.global_event_id = ${input.eventId}
+        ORDER BY em.mention_time DESC
+      `);
+
+      const evtRows = await db.execute(sql`
+        SELECT num_mentions, num_sources, avg_tone
+        FROM gdelt_events
+        WHERE global_event_id = ${input.eventId}
+        LIMIT 1
+      `);
+
+      const evt = evtRows.rows[0] as {
+        num_mentions: number | null;
+        num_sources: number | null;
+        avg_tone: number | null;
+      } | undefined;
+
+      type MentionRow = {
+        id: string;
+        url: string;
+        domain: string | null;
+        mention_time: string | null;
+        doc_tone: number | null;
+        title: string | null;
+      };
+
+      const headlines = (mentionRows.rows as MentionRow[]).map((r) => {
+        let source = r.domain;
+        if (!source) {
+          try {
+            source = new URL(r.url).hostname.replace(/^www\./, "");
+          } catch {
+            source = r.url;
+          }
+        }
+        return {
+          id: r.id,
+          title: r.title || "(untitled)",
+          source,
+          url: r.url,
+          createdAt: r.mention_time,
+        };
+      });
+
+      const uniqueSources = new Set(headlines.map((h) => h.source)).size;
+
+      return {
+        eventId: input.eventId,
+        mentionCount: evt?.num_mentions ?? headlines.length,
+        sourceCount: evt?.num_sources ?? uniqueSources,
+        avgTone: evt?.avg_tone ?? null,
+        headlines,
+      };
+    }),
+
+  /**
+   * Look up the highest-mention GDELT event for a given document URL.
+   * Used by FeedCard to show a Coverage button when the doc belongs to
+   * a high-signal event (>15 mentions).
+   */
+  eventsByDocUrl: publicProcedure
+    .input(z.object({ url: z.string() }))
+    .query(async ({ input }) => {
+      const rows = await db.execute(sql`
+        SELECT
+          e.global_event_id,
+          e.num_mentions,
+          e.num_sources,
+          e.avg_tone,
+          e.actor1_name,
+          e.actor2_name,
+          e.event_time,
+          e.action_geo_fullname
+        FROM gdelt_event_mentions em
+        JOIN gdelt_events e ON e.global_event_id = em.global_event_id
+        WHERE em.url = ${input.url}
+          AND e.num_mentions > 15
+        ORDER BY e.num_mentions DESC
+        LIMIT 1
+      `);
+
+      type EventRow = {
+        global_event_id: string;
+        num_mentions: number | null;
+        num_sources: number | null;
+        avg_tone: number | null;
+        actor1_name: string | null;
+        actor2_name: string | null;
+        event_time: string | null;
+        action_geo_fullname: string | null;
+      };
+
+      return (rows.rows as EventRow[]).map((r) => ({
+        globalEventId: r.global_event_id,
+        numMentions: r.num_mentions,
+        numSources: r.num_sources,
+        avgTone: r.avg_tone,
+        actor1Name: r.actor1_name,
+        actor2Name: r.actor2_name,
+        eventTime: r.event_time,
+        actionGeoFullname: r.action_geo_fullname,
+      }));
     }),
 });


### PR DESCRIPTION
## Summary
Adds a comprehensive event coverage view to the feed, allowing users to explore related headlines for high-signal GDELT events. Includes intelligent client-side headline clustering and a detailed modal interface with coverage statistics.

## Key Changes

**New Components:**
- `EventDetailCoverageTab`: Displays clustered headlines for an event with coverage overview stats (mention count, source count, sentiment tone). Features expandable clusters sorted by mention count, with country flags for each news source.
- `EventDetailModal`: Full-screen modal with two tabs—Coverage (headline clusters) and Overview (event metadata like actors, location, event ID).

**Backend Enhancements:**
- `coverage` procedure: Fetches all mention headlines for a GDELT event, joins with document titles, and returns aggregated coverage metrics.
- `eventsByDocUrl` procedure: Looks up the highest-mention GDELT event (>15 mentions) for a given document URL, enabling the Coverage button on feed cards.

**Frontend Integration:**
- Updated `FeedCard` to include a "Coverage" button that lazily fetches related events and opens the modal on click.
- Implements lazy loading: network request only fires when user clicks Coverage, improving performance.

## Notable Implementation Details

- **Headline Clustering**: Uses greedy single-linkage clustering with Jaccard similarity (threshold 0.25) on tokenized headlines. Filters stop words and groups similar narratives together. Singletons are collected into an "Other" cluster.
- **Country Flags**: Maps news domains to country flags via TLD lookup with hardcoded overrides for major outlets (Reuters, BBC, CNN, etc.).
- **Responsive Design**: Modal uses bottom sheet on mobile, centered dialog on desktop. Expandable clusters with preview/show-all toggle for large mention counts.
- **Tone Visualization**: Color-codes sentiment (red for negative, orange for mixed, green for positive) across both the modal and coverage header.

https://claude.ai/code/session_01Q57F7ZEAeXDDhfvby2FPnS