### PR TITLE
feat(events): configurable columns with Event Type, Sources, and Goldstein

### DIFF
--- a/client/src/pages/IntelEventsPage.tsx
+++ b/client/src/pages/IntelEventsPage.tsx
@@ -1,9 +1,18 @@
 import { useState, useEffect } from "react";
 import { useDebounce } from "use-debounce";
 import { useInView } from "react-intersection-observer";
-import { Loader2, MapPin, Users, BarChart2 } from "lucide-react";
+import { MapPin, Users, BarChart2, SlidersHorizontal } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { EventDetailModal } from "@/components/intelfeed/EventDetailModal";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
 
 type EventItem = {
   globalEventId: string;
@@ -15,6 +24,30 @@ type EventItem = {
   numSources: number | null;
   avgTone: number | null;
   actionGeoFullname: string | null;
+  goldstein: number | null;
+  numArticles: number | null;
+  eventCodeName: string | null;
+};
+
+// ─── Column system ────────────────────────────────────────────────────────────
+
+type ColumnKey =
+  | "actors"
+  | "location"
+  | "mentions"
+  | "tone"
+  | "date"
+  | "coverage"
+  | "eventType"
+  | "sources"
+  | "goldstein";
+
+type ColumnDef = {
+  key: ColumnKey;
+  label: string;
+  defaultVisible: boolean;
+  renderHeader: () => React.ReactNode;
+  renderCell: (event: EventItem) => React.ReactNode;
 };
 
 function toneColor(tone: number | null): string {
@@ -26,7 +59,6 @@ function toneColor(tone: number | null): string {
 
 function MentionBar({ count }: { count: number | null }) {
   const n = count ?? 0;
-  // Cap visual bar at 200 mentions
   const pct = Math.min(100, (n / 200) * 100);
   return (
     <div className="flex items-center gap-2">
@@ -41,56 +73,64 @@ function MentionBar({ count }: { count: number | null }) {
   );
 }
 
-function EventRow({
-  event,
-  onSelect,
-}: {
-  event: EventItem;
-  onSelect: (e: EventItem) => void;
-}) {
-  const actors = [event.actor1Name, event.actor2Name].filter(Boolean);
-
-  return (
-    <tr
-      className="border-b last:border-b-0 hover:bg-muted/50 cursor-pointer transition-colors"
-      onClick={() => onSelect(event)}
-    >
-      {/* Actors */}
-      <td className="py-3 px-4">
-        {actors.length > 0 ? (
-          <div className="flex items-center gap-1.5 text-sm font-medium">
-            <Users className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
-            <span className="truncate max-w-[200px]">{actors.join(" ↔ ")}</span>
-          </div>
-        ) : (
-          <span className="text-sm text-muted-foreground">(unknown actors)</span>
-        )}
-      </td>
-
-      {/* Geo */}
-      <td className="py-3 px-4 hidden sm:table-cell">
-        {event.actionGeoFullname ? (
-          <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
-            <MapPin className="h-3.5 w-3.5 flex-shrink-0" />
-            <span className="truncate max-w-[180px]">{event.actionGeoFullname}</span>
-          </div>
-        ) : (
-          <span className="text-sm text-muted-foreground">—</span>
-        )}
-      </td>
-
-      {/* Mentions bar */}
-      <td className="py-3 px-4">
-        <MentionBar count={event.numMentions} />
-      </td>
-
-      {/* Tone */}
-      <td className={`py-3 px-4 text-sm tabular-nums font-medium ${toneColor(event.avgTone)}`}>
+const COLUMN_DEFS: ColumnDef[] = [
+  {
+    key: "actors",
+    label: "Actors",
+    defaultVisible: true,
+    renderHeader: () => "Actors",
+    renderCell: (event) => {
+      const actors = [event.actor1Name, event.actor2Name].filter(Boolean);
+      return actors.length > 0 ? (
+        <div className="flex items-center gap-1.5 text-sm font-medium">
+          <Users className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+          <span className="truncate max-w-[200px]">{actors.join(" ↔ ")}</span>
+        </div>
+      ) : (
+        <span className="text-sm text-muted-foreground">(unknown actors)</span>
+      );
+    },
+  },
+  {
+    key: "location",
+    label: "Location",
+    defaultVisible: true,
+    renderHeader: () => "Location",
+    renderCell: (event) =>
+      event.actionGeoFullname ? (
+        <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+          <MapPin className="h-3.5 w-3.5 flex-shrink-0" />
+          <span className="truncate max-w-[180px]">{event.actionGeoFullname}</span>
+        </div>
+      ) : (
+        <span className="text-sm text-muted-foreground">—</span>
+      ),
+  },
+  {
+    key: "mentions",
+    label: "Mentions",
+    defaultVisible: true,
+    renderHeader: () => "Mentions",
+    renderCell: (event) => <MentionBar count={event.numMentions} />,
+  },
+  {
+    key: "tone",
+    label: "Tone",
+    defaultVisible: true,
+    renderHeader: () => "Tone",
+    renderCell: (event) => (
+      <span className={`text-sm tabular-nums font-medium ${toneColor(event.avgTone)}`}>
         {event.avgTone != null ? event.avgTone.toFixed(1) : "—"}
-      </td>
-
-      {/* Time */}
-      <td className="py-3 px-4 text-sm text-muted-foreground tabular-nums whitespace-nowrap hidden md:table-cell">
+      </span>
+    ),
+  },
+  {
+    key: "date",
+    label: "Date",
+    defaultVisible: true,
+    renderHeader: () => "Date",
+    renderCell: (event) => (
+      <span className="text-sm text-muted-foreground tabular-nums whitespace-nowrap">
         {event.eventTime
           ? new Date(event.eventTime).toLocaleDateString(undefined, {
               month: "short",
@@ -98,39 +138,174 @@ function EventRow({
               year: "numeric",
             })
           : "—"}
-      </td>
+      </span>
+    ),
+  },
+  {
+    key: "coverage",
+    label: "Coverage",
+    defaultVisible: true,
+    renderHeader: () => "Coverage",
+    renderCell: (event) =>
+      (event.numMentions ?? 0) >= 3 ? (
+        <span className="inline-flex items-center gap-1 text-xs text-blue-600 font-medium">
+          <BarChart2 className="h-3.5 w-3.5" />
+          Coverage
+        </span>
+      ) : (
+        <span className="text-xs text-muted-foreground">—</span>
+      ),
+  },
+  {
+    key: "eventType",
+    label: "Event Type",
+    defaultVisible: false,
+    renderHeader: () => "Event Type",
+    renderCell: (event) => (
+      <span className="text-sm text-muted-foreground">
+        {event.eventCodeName ?? event.eventCode ?? "—"}
+      </span>
+    ),
+  },
+  {
+    key: "sources",
+    label: "Sources",
+    defaultVisible: false,
+    renderHeader: () => "Sources",
+    renderCell: (event) => (
+      <span className="text-sm tabular-nums">
+        {event.numSources != null ? event.numSources : "—"}
+      </span>
+    ),
+  },
+  {
+    key: "goldstein",
+    label: "Goldstein",
+    defaultVisible: false,
+    renderHeader: () => "Goldstein",
+    renderCell: (event) => (
+      <span
+        className={`text-sm tabular-nums font-medium ${
+          event.goldstein == null
+            ? "text-muted-foreground"
+            : event.goldstein < 0
+            ? "text-orange-500"
+            : "text-emerald-600"
+        }`}
+      >
+        {event.goldstein != null ? event.goldstein.toFixed(1) : "—"}
+      </span>
+    ),
+  },
+];
 
-      {/* Coverage CTA */}
-      <td className="py-3 px-4">
-        {(event.numMentions ?? 0) >= 3 ? (
-          <span className="inline-flex items-center gap-1 text-xs text-blue-600 font-medium">
-            <BarChart2 className="h-3.5 w-3.5" />
-            Coverage
-          </span>
-        ) : (
-          <span className="text-xs text-muted-foreground">—</span>
-        )}
-      </td>
-    </tr>
+const DEFAULT_VISIBLE = new Set<ColumnKey>(
+  COLUMN_DEFS.filter((c) => c.defaultVisible).map((c) => c.key),
+);
+const LS_KEY = "events-columns";
+
+// ─── Hooks ────────────────────────────────────────────────────────────────────
+
+function useColumnVisibility(): [Set<ColumnKey>, (key: ColumnKey, on: boolean) => void] {
+  const [visible, setVisible] = useState<Set<ColumnKey>>(() => {
+    try {
+      const stored = localStorage.getItem(LS_KEY);
+      if (stored) return new Set(JSON.parse(stored) as ColumnKey[]);
+    } catch {
+      // ignore parse errors
+    }
+    return DEFAULT_VISIBLE;
+  });
+
+  const toggle = (key: ColumnKey, on: boolean) => {
+    setVisible((prev) => {
+      if (!on && prev.size <= 1) return prev; // prevent empty set
+      const next = new Set(prev);
+      on ? next.add(key) : next.delete(key);
+      localStorage.setItem(LS_KEY, JSON.stringify([...next]));
+      return next;
+    });
+  };
+
+  return [visible, toggle];
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function ColumnPicker({
+  visible,
+  onToggle,
+}: {
+  visible: Set<ColumnKey>;
+  onToggle: (key: ColumnKey, on: boolean) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="h-10 gap-1.5">
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+          Columns
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuLabel>Visible columns</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {COLUMN_DEFS.map((col) => (
+          <DropdownMenuCheckboxItem
+            key={col.key}
+            checked={visible.has(col.key)}
+            onCheckedChange={(checked) => onToggle(col.key, !!checked)}
+          >
+            {col.label}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
-function Skeleton() {
+function EventRow({
+  event,
+  visibleColumns,
+  onSelect,
+}: {
+  event: EventItem;
+  visibleColumns: Set<ColumnKey>;
+  onSelect: (e: EventItem) => void;
+}) {
   return (
-    <tr className="border-b">
-      {[...Array(6)].map((_, i) => (
-        <td key={i} className="py-3 px-4">
-          <div className="h-4 rounded bg-muted animate-pulse" style={{ width: `${60 + i * 10}%` }} />
+    <tr
+      className="border-b last:border-b-0 hover:bg-muted/50 cursor-pointer transition-colors"
+      onClick={() => onSelect(event)}
+    >
+      {COLUMN_DEFS.filter((col) => visibleColumns.has(col.key)).map((col) => (
+        <td key={col.key} className="py-3 px-4">
+          {col.renderCell(event)}
         </td>
       ))}
     </tr>
   );
 }
 
+function Skeleton({ columnCount }: { columnCount: number }) {
+  return (
+    <tr className="border-b">
+      {[...Array(columnCount)].map((_, i) => (
+        <td key={i} className="py-3 px-4">
+          <div className="h-4 rounded bg-muted animate-pulse" style={{ width: `${60 + i * 8}%` }} />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
 export default function IntelEventsPage() {
   const [q, setQ] = useState("");
   const [debounced] = useDebounce(q, 350);
   const [selectedEvent, setSelectedEvent] = useState<EventItem | null>(null);
+  const [visibleColumns, toggleColumn] = useColumnVisibility();
 
   const { ref, inView } = useInView();
 
@@ -146,6 +321,7 @@ export default function IntelEventsPage() {
   }, [inView, query]);
 
   const items = query.data?.pages.flatMap((p) => p.items) ?? [];
+  const activeColumnCount = COLUMN_DEFS.filter((c) => visibleColumns.has(c.key)).length;
 
   return (
     <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
@@ -157,14 +333,15 @@ export default function IntelEventsPage() {
         </p>
       </div>
 
-      {/* Search */}
-      <div className="mb-4">
+      {/* Search + column picker */}
+      <div className="mb-4 flex items-center gap-2">
         <input
           className="h-10 w-full max-w-sm rounded-md border bg-background px-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           placeholder="Filter by actor or location…"
           value={q}
           onChange={(e) => setQ(e.target.value)}
         />
+        <ColumnPicker visible={visibleColumns} onToggle={toggleColumn} />
       </div>
 
       {/* Table */}
@@ -172,21 +349,22 @@ export default function IntelEventsPage() {
         <table className="w-full text-sm">
           <thead className="text-left text-xs text-muted-foreground border-b">
             <tr>
-              <th className="py-3 px-4 font-medium">Actors</th>
-              <th className="py-3 px-4 font-medium hidden sm:table-cell">Location</th>
-              <th className="py-3 px-4 font-medium">Mentions</th>
-              <th className="py-3 px-4 font-medium">Tone</th>
-              <th className="py-3 px-4 font-medium hidden md:table-cell">Date</th>
-              <th className="py-3 px-4 font-medium">Coverage</th>
+              {COLUMN_DEFS.filter((col) => visibleColumns.has(col.key)).map((col) => (
+                <th key={col.key} className="py-3 px-4 font-medium">
+                  {col.renderHeader()}
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>
             {query.isLoading
-              ? [...Array(8)].map((_, i) => <Skeleton key={i} />)
+              ? [...Array(8)].map((_, i) => (
+                  <Skeleton key={i} columnCount={activeColumnCount} />
+                ))
               : query.isError
               ? (
                 <tr>
-                  <td colSpan={6} className="py-8 px-4 text-center text-sm text-muted-foreground">
+                  <td colSpan={activeColumnCount} className="py-8 px-4 text-center text-sm text-muted-foreground">
                     Failed to load events — {query.error?.message}
                   </td>
                 </tr>
@@ -194,16 +372,23 @@ export default function IntelEventsPage() {
               : items.length === 0
               ? (
                 <tr>
-                  <td colSpan={6} className="py-8 px-4 text-center text-sm text-muted-foreground">
+                  <td colSpan={activeColumnCount} className="py-8 px-4 text-center text-sm text-muted-foreground">
                     {debounced.length >= 2 ? "No events match your search." : "No events found."}
                   </td>
                 </tr>
               )
               : items.map((event) => (
-                <EventRow key={event.globalEventId} event={event} onSelect={setSelectedEvent} />
+                <EventRow
+                  key={event.globalEventId}
+                  event={event}
+                  visibleColumns={visibleColumns}
+                  onSelect={setSelectedEvent}
+                />
               ))}
 
-            {query.isFetchingNextPage && <Skeleton />}
+            {query.isFetchingNextPage && (
+              <Skeleton columnCount={activeColumnCount} />
+            )}
           </tbody>
         </table>
       </div>

--- a/server/routers/intelRouter.ts
+++ b/server/routers/intelRouter.ts
@@ -227,6 +227,9 @@ export const intelRouter = router({
         num_sources: number | null;
         avg_tone: number | null;
         action_geo_fullname: string | null;
+        goldstein: number | null;
+        num_articles: number | null;
+        event_code_name: string | null;
       };
 
       let result;
@@ -240,32 +243,38 @@ export const intelRouter = router({
 
           result = await db.execute(sql`
             SELECT
-              global_event_id, event_time, actor1_name, actor2_name,
-              event_code, num_mentions, num_sources, avg_tone, action_geo_fullname
-            FROM gdelt_events
-            WHERE num_mentions >= 1
+              e.global_event_id, e.event_time, e.actor1_name, e.actor2_name,
+              e.event_code, e.num_mentions, e.num_sources, e.avg_tone,
+              e.action_geo_fullname, e.goldstein, e.num_articles,
+              ec.name AS event_code_name
+            FROM gdelt_events e
+            LEFT JOIN event_codes ec ON ec.code = e.event_code
+            WHERE e.num_mentions >= 1
               AND (
-                actor1_name ILIKE ${like}
-                OR actor2_name ILIKE ${like}
-                OR action_geo_fullname ILIKE ${like}
+                e.actor1_name ILIKE ${like}
+                OR e.actor2_name ILIKE ${like}
+                OR e.action_geo_fullname ILIKE ${like}
               )
-              AND (num_mentions, global_event_id) < (${cursorMentions}::int, ${cursorId})
-            ORDER BY num_mentions DESC NULLS LAST, global_event_id DESC
+              AND (e.num_mentions, e.global_event_id) < (${cursorMentions}::int, ${cursorId})
+            ORDER BY e.num_mentions DESC NULLS LAST, e.global_event_id DESC
             LIMIT ${limitPlusOne}
           `);
         } else {
           result = await db.execute(sql`
             SELECT
-              global_event_id, event_time, actor1_name, actor2_name,
-              event_code, num_mentions, num_sources, avg_tone, action_geo_fullname
-            FROM gdelt_events
-            WHERE num_mentions >= 1
+              e.global_event_id, e.event_time, e.actor1_name, e.actor2_name,
+              e.event_code, e.num_mentions, e.num_sources, e.avg_tone,
+              e.action_geo_fullname, e.goldstein, e.num_articles,
+              ec.name AS event_code_name
+            FROM gdelt_events e
+            LEFT JOIN event_codes ec ON ec.code = e.event_code
+            WHERE e.num_mentions >= 1
               AND (
-                actor1_name ILIKE ${like}
-                OR actor2_name ILIKE ${like}
-                OR action_geo_fullname ILIKE ${like}
+                e.actor1_name ILIKE ${like}
+                OR e.actor2_name ILIKE ${like}
+                OR e.action_geo_fullname ILIKE ${like}
               )
-            ORDER BY num_mentions DESC NULLS LAST, global_event_id DESC
+            ORDER BY e.num_mentions DESC NULLS LAST, e.global_event_id DESC
             LIMIT ${limitPlusOne}
           `);
         }
@@ -276,22 +285,28 @@ export const intelRouter = router({
 
         result = await db.execute(sql`
           SELECT
-            global_event_id, event_time, actor1_name, actor2_name,
-            event_code, num_mentions, num_sources, avg_tone, action_geo_fullname
-          FROM gdelt_events
-          WHERE num_mentions >= 1
-            AND (num_mentions, global_event_id) < (${cursorMentions}::int, ${cursorId})
-          ORDER BY num_mentions DESC NULLS LAST, global_event_id DESC
+            e.global_event_id, e.event_time, e.actor1_name, e.actor2_name,
+            e.event_code, e.num_mentions, e.num_sources, e.avg_tone,
+            e.action_geo_fullname, e.goldstein, e.num_articles,
+            ec.name AS event_code_name
+          FROM gdelt_events e
+          LEFT JOIN event_codes ec ON ec.code = e.event_code
+          WHERE e.num_mentions >= 1
+            AND (e.num_mentions, e.global_event_id) < (${cursorMentions}::int, ${cursorId})
+          ORDER BY e.num_mentions DESC NULLS LAST, e.global_event_id DESC
           LIMIT ${limitPlusOne}
         `);
       } else {
         result = await db.execute(sql`
           SELECT
-            global_event_id, event_time, actor1_name, actor2_name,
-            event_code, num_mentions, num_sources, avg_tone, action_geo_fullname
-          FROM gdelt_events
-          WHERE num_mentions >= 1
-          ORDER BY num_mentions DESC NULLS LAST, global_event_id DESC
+            e.global_event_id, e.event_time, e.actor1_name, e.actor2_name,
+            e.event_code, e.num_mentions, e.num_sources, e.avg_tone,
+            e.action_geo_fullname, e.goldstein, e.num_articles,
+            ec.name AS event_code_name
+          FROM gdelt_events e
+          LEFT JOIN event_codes ec ON ec.code = e.event_code
+          WHERE e.num_mentions >= 1
+          ORDER BY e.num_mentions DESC NULLS LAST, e.global_event_id DESC
           LIMIT ${limitPlusOne}
         `);
       }
@@ -317,6 +332,9 @@ export const intelRouter = router({
           numSources: r.num_sources,
           avgTone: r.avg_tone,
           actionGeoFullname: r.action_geo_fullname,
+          goldstein: r.goldstein,
+          numArticles: r.num_articles,
+          eventCodeName: r.event_code_name,
         })),
         nextCursor,
       };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a **Columns** picker button (dropdown with checkboxes) next to the search bar on `/intel/events`, letting analysts choose which columns to display
- Persists selection in `localStorage` under key `events-columns` — survives page refreshes
- Three new opt-in columns expose data that was already in the database but never surfaced:
  - **Event Type** — human-readable CAMEO event category name (e.g. "Threaten", "Protest", "Make statement") via `LEFT JOIN event_codes` on the backend
  - **Sources** — distinct source domain count (`numSources` was already returned by the API but never rendered)
  - **Goldstein** — conflict/cooperation scale score (−10 to +10), colour-coded orange/emerald
- Default visible set is unchanged: Actors, Location, Mentions, Tone, Date, Coverage

## Changes

**`server/routers/intelRouter.ts`**
- All 4 SQL branches in `listEvents` extended with `LEFT JOIN event_codes ec ON ec.code = e.event_code` and three new selected columns: `e.goldstein`, `e.num_articles`, `ec.name AS event_code_name`
- `EventListRow` type and return mapping updated to include the new fields

**`client/src/pages/IntelEventsPage.tsx`**
- `EventItem` type extended with `goldstein`, `numArticles`, `eventCodeName`
- `COLUMN_DEFS` registry drives header and cell rendering for all 9 columns
- `useColumnVisibility` hook manages localStorage persistence
- `ColumnPicker` component uses existing `DropdownMenuCheckboxItem` from the UI library
- `EventRow` and `Skeleton` are now data-driven; `colSpan` on empty/error rows tracks active column count

## Test plan

- [ ] Open `/intel/events` — default layout is identical to before
- [ ] Click **Columns** — dropdown lists all 9 columns with the default 6 checked
- [ ] Toggle **Event Type** on — column appears with CAMEO names (e.g. "Make statement")
- [ ] Toggle **Actors** off — column disappears without breaking layout
- [ ] Reload page — column selection is restored from localStorage
- [ ] Toggle **Sources** and **Goldstein** on — numeric values render with correct colour coding
- [ ] Verify skeleton rows and empty/error states show the correct number of cells

https://claude.ai/code/session_016v3t91EWFpPs8swjqMS557
EOF
)