### PR TITLE
Add TECHSTACK.md with section headings skeleton

### DIFF
--- a/docs/TECHSTACK.md
+++ b/docs/TECHSTACK.md
@@ -1,0 +1,34 @@
+# Horizon — Tech Stack
+
+> *"The specific technical choices that serve the vision without over-committing."*
+> — VISION.md, section 10
+
+## 1. Guiding principles
+
+## 2. Architecture at a glance
+
+## 3. Storage — PostgreSQL + Drizzle ORM
+
+## 4. API layer — tRPC + Express
+
+## 5. Ingestion — GDELT pipeline
+
+## 6. AI / NLP — OpenAI (optional, bounded)
+
+## 7. UI — React + Vite + shadcn/ui
+
+## 8. Authentication & sessions
+
+## 9. Validation & shared types
+
+## 10. Type safety — the through-line
+
+## 11. Testing
+
+## 12. Build & dev tooling
+
+## 13. Deployment & hosting
+
+## 14. Environment variables
+
+## 15. What we deliberately don't use (and why)


### PR DESCRIPTION
Scaffolds the 15-section structure for the tech stack document called for in VISION.md section 10. Content to follow.

https://claude.ai/code/session_01ST7s1h45Q2M8EZ4HbxENDt