### PR TITLE
Phase 0.5: rewrite SubNavigationBar to vision-aligned nav items

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -31,7 +31,7 @@ themes → scenarios → indicators → events model. No mock or hardcoded retur
 
 ### Navigation & routing
 
-- [ ] Rewrite `SubNavigationBar.tsx` `SUB_NAV_ITEMS` to contain only: Overview (`/horizon/overview`), Themes (`/themes`), Scenarios (`/horizon/scenarios`), Signals (`/horizon/signals`), Updates (`/horizon/updates`), Reports (`/horizon/reports`), Intel Feed (`/intel/feed`), Events (`/intel/events`)
+- [x] Rewrite `SubNavigationBar.tsx` `SUB_NAV_ITEMS` to contain only: Overview (`/horizon/overview`), Themes (`/themes`), Scenarios (`/horizon/scenarios`), Signals (`/horizon/signals`), Updates (`/horizon/updates`), Reports (`/horizon/reports`), Intel Feed (`/intel/feed`), Events (`/intel/events`)
 - [ ] Remove the `/snippet/create`, `/snippet/show`, `/snippet/:id`, `/snippet/:id/edit`, `/tags/show`, `/sources`, `/sources/recent`, and `/webcut` routes from `client/src/App.tsx` (keep the page files; just unregister the routes)
 - [ ] Remove the `GlobalSearch` component from `NavigationBar.tsx` — it queries snippets and sources, which are now unreachable; replace with a plain wordmark link until a vision-aligned search exists
 

--- a/client/src/components/SubNavigationBar.tsx
+++ b/client/src/components/SubNavigationBar.tsx
@@ -8,14 +8,14 @@ interface SubNavItem {
 }
 
 const SUB_NAV_ITEMS: SubNavItem[] = [
-  { linkName: "Snippets", href: "/snippet/show" },
+  { linkName: "Overview", href: "/horizon/overview" },
   { linkName: "Themes", href: "/themes" },
-  { linkName: "Tags", href: "/tags/show" },
-  { linkName: "Trends", href: "/horizon/overview" },
   { linkName: "Scenarios", href: "/horizon/scenarios" },
+  { linkName: "Signals", href: "/horizon/signals" },
+  { linkName: "Updates", href: "/horizon/updates" },
+  { linkName: "Reports", href: "/horizon/reports" },
   { linkName: "Intel Feed", href: "/intel/feed" },
   { linkName: "Events", href: "/intel/events" },
-  { linkName: "Sources", href: "/sources/recent" },
 ];
 
 function isActiveRoute(pathname: string, href: string): boolean {


### PR DESCRIPTION
## Summary

- Replaces the old `SUB_NAV_ITEMS` array (Snippets, Tags, Trends, Sources) with the eight nav items described in the Phase 0.5 task: Overview, Themes, Scenarios, Signals, Updates, Reports, Intel Feed, Events
- Marks the first Phase 0.5 subtask complete in `TASKS.md`

## Test plan

- [ ] Log in and verify the sub-nav shows exactly: Overview, Themes, Scenarios, Signals, Updates, Reports, Intel Feed, Events — no more, no less
- [ ] Confirm each link routes to the correct path

https://claude.ai/code/session_01VryA3Snv7o7bkmUtaTDJZr