### PR TITLE
remove unreachable snippet, tag, source, and webcut routes

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -32,7 +32,7 @@ themes → scenarios → indicators → events model. No mock or hardcoded retur
 ### Navigation & routing
 
 - [x] Rewrite `SubNavigationBar.tsx` `SUB_NAV_ITEMS` to contain only: Overview (`/horizon/overview`), Themes (`/themes`), Scenarios (`/horizon/scenarios`), Signals (`/horizon/signals`), Updates (`/horizon/updates`), Reports (`/horizon/reports`), Intel Feed (`/intel/feed`), Events (`/intel/events`)
-- [ ] Remove the `/snippet/create`, `/snippet/show`, `/snippet/:id`, `/snippet/:id/edit`, `/tags/show`, `/sources`, `/sources/recent`, and `/webcut` routes from `client/src/App.tsx` (keep the page files; just unregister the routes)
+- [x] Remove the `/snippet/create`, `/snippet/show`, `/snippet/:id`, `/snippet/:id/edit`, `/tags/show`, `/sources`, `/sources/recent`, and `/webcut` routes from `client/src/App.tsx` (keep the page files; just unregister the routes)
 - [ ] Remove the `GlobalSearch` component from `NavigationBar.tsx` — it queries snippets and sources, which are now unreachable; replace with a plain wordmark link until a vision-aligned search exists
 
 ---

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,15 +5,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { trpc, trpcClient } from "@/lib/trpc";
 import NotFound from "@/pages/not-found";
 import Home from "@/pages/home";
-import SnippetScreen from "./pages/SnippetScreen";
 import NavigationBar from "@/components/NavigationBar";
 import SubNavigationBar from "@/components/SubNavigationBar";
-import SnippetTable from "./pages/SnippetTable";
-import EditSnippetScreen from "./pages/EditSnippetScreen";
-import TagsScreen from "./pages/TagsScreen";
-import SnippetViewScreen from "@/pages/SnippetViewScreen";
-import RecentSourcesScreen from "@/pages/RecentSourcesScreen";
-import WebcutScreen from "@/pages/WebcutScreen";
 import AdminScreen from "@/pages/AdminScreen";
 import ThemeViewScreen from "@/pages/ThemeViewScreen";
 import ThemeCreateForm from "@/pages/forms/ThemeCreateForm";
@@ -31,7 +24,6 @@ import HorizonSignalsScreen from "@/pages/HorizonSignalsScreen";
 import HorizonIndicatorDetailScreen from "@/pages/HorizonIndicatorDetailScreen";
 import HorizonUpdatesScreen from "@/pages/HorizonUpdatesScreen";
 import HorizonReportsScreen from "@/pages/HorizonReportsScreen"
-import SourcesScreen from "@/pages/SourcesScreen"
 import IntelFeed from "@/pages/IntelFeed"
 import IntelEventsPage from "@/pages/IntelEventsPage"
 
@@ -111,50 +103,9 @@ function Router() {
           <IntelEventsPage />
         </RequireAuth>
       </Route>
-      <Route path="/sources">
-        <RequireAuth>
-         <SourcesScreen/>
-        </RequireAuth>
-      </Route>
 
       <Route path="/signup">
         <SignupForm />
-      </Route>
-
-      <Route path="/snippet/create">
-        <RequireAuth>
-          <SnippetScreen />
-        </RequireAuth>
-      </Route>
-
-      <Route path="/snippet/show">
-        <RequireAuth>
-          <SnippetTable />
-        </RequireAuth>
-      </Route>
-
-      <Route path="/snippet/:id/edit">
-        <RequireAuth>
-          <EditSnippetScreen />
-        </RequireAuth>
-      </Route>
-
-      <Route path="/snippet/:id">
-        <RequireAuth>
-          <SnippetViewScreen />
-        </RequireAuth>
-      </Route>
-
-      <Route path="/sources/recent">
-        <RequireAuth>
-          <RecentSourcesScreen />
-        </RequireAuth>
-      </Route>
-
-      <Route path="/tags/show">
-        <RequireAuth>
-          <TagsScreen />
-        </RequireAuth>
       </Route>
 
       <Route path="/themes">
@@ -178,12 +129,6 @@ function Router() {
       <Route path="/theme/:id">
         <RequireAuth>
           <ThemeViewScreen />
-        </RequireAuth>
-      </Route>
-
-      <Route path="/webcut">
-        <RequireAuth>
-          <WebcutScreen />
         </RequireAuth>
       </Route>
 


### PR DESCRIPTION
## Summary

Completes the second navigation cleanup subtask in Phase 0.5 of `TASKS.md`.

Unregisters the eight routes that no longer appear in the vision-aligned nav:

- `/snippet/create`, `/snippet/show`, `/snippet/:id`, `/snippet/:id/edit`
- `/tags/show`
- `/sources`, `/sources/recent`
- `/webcut`

The page component files are kept in place per the task spec — only the `<Route>` registrations and their now-unused imports in `client/src/App.tsx` were removed. Any direct navigation to these paths now falls through to `NotFound`.

## Test plan

- [ ] `npm run dev` and confirm removed paths render NotFound
- [ ] Confirm remaining nav links (Overview, Themes, Scenarios, Signals, Updates, Reports, Intel Feed, Events) still resolve
- [ ] `npm run build` succeeds