### PR TITLE
remove GlobalSearch from NavigationBar

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -33,7 +33,7 @@ themes → scenarios → indicators → events model. No mock or hardcoded retur
 
 - [x] Rewrite `SubNavigationBar.tsx` `SUB_NAV_ITEMS` to contain only: Overview (`/horizon/overview`), Themes (`/themes`), Scenarios (`/horizon/scenarios`), Signals (`/horizon/signals`), Updates (`/horizon/updates`), Reports (`/horizon/reports`), Intel Feed (`/intel/feed`), Events (`/intel/events`)
 - [x] Remove the `/snippet/create`, `/snippet/show`, `/snippet/:id`, `/snippet/:id/edit`, `/tags/show`, `/sources`, `/sources/recent`, and `/webcut` routes from `client/src/App.tsx` (keep the page files; just unregister the routes)
-- [ ] Remove the `GlobalSearch` component from `NavigationBar.tsx` — it queries snippets and sources, which are now unreachable; replace with a plain wordmark link until a vision-aligned search exists
+- [x] Remove the `GlobalSearch` component from `NavigationBar.tsx` — it queries snippets and sources, which are now unreachable; replace with a plain wordmark link until a vision-aligned search exists
 
 ---
 

--- a/client/src/components/NavigationBar.test.tsx
+++ b/client/src/components/NavigationBar.test.tsx
@@ -20,11 +20,6 @@ vi.mock("@/lib/trpc", () => ({
   },
 }));
 
-vi.mock("@/components/GlobalSearch", () => ({
-  GlobalSearch: () => null,
-  default: () => null,
-}));
-
 vi.mock("@/hooks/useSession", () => ({
   useSession: vi.fn(() => ({
     user: { username: "Jo", role: "user" },

--- a/client/src/components/NavigationBar.tsx
+++ b/client/src/components/NavigationBar.tsx
@@ -2,7 +2,6 @@
 
 import { Link } from "wouter";
 import { cn } from "@/lib/utils";
-import { GlobalSearch } from "@/components/GlobalSearch";
 import { trpc } from "@/lib/trpc";
 import { useSession } from "@/hooks/useSession";
 import {
@@ -51,13 +50,6 @@ export default function NavigationBar() {
             </div>
           </Link>
 
-          {/* Search — hidden on xs, shown on sm+ */}
-         {isAuthenticated && <div className="hidden sm:flex flex-1 justify-center">
-            <div className="w-full max-w-xl">
-              <GlobalSearch />
-            </div>
-          </div>}
-
           {/* Auth controls */}
           <div className="flex items-center gap-2 shrink-0">
             {isLoading ? null : isAuthenticated ? (
@@ -105,11 +97,6 @@ export default function NavigationBar() {
               </div>
             )}
           </div>
-        </div>
-
-        {/* Mobile search */}
-        <div className="sm:hidden pb-3">
-          {isAuthenticated && <GlobalSearch />}
         </div>
       </nav>
     </header>


### PR DESCRIPTION
## Summary

- Remove `GlobalSearch` usage from `NavigationBar.tsx` (desktop + mobile) and drop its import. The wordmark link to `/` is retained as the brand element.
- Drop the now-unused `GlobalSearch` vi.mock from `NavigationBar.test.tsx`.
- Tick off the corresponding Phase 0.5 subtask in `TASKS.md`.

`GlobalSearch` queried snippets and sources, both of which are no longer reachable after the nav/route cleanup. A vision-aligned search will replace it in a later phase.

## Test plan

- [ ] `npm test` — NavigationBar tests still pass (brand, avatar, Sign In/Sign Up, no page nav links in top bar).
- [ ] Manual: verify the top bar shows only the wordmark + user/auth controls and that no search input renders on any viewport.

https://claude.ai/code/session_01Pyhticzw8x7SQaymfZ8ThZ